### PR TITLE
Add markdownlint config and workflow

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -1,0 +1,41 @@
+name: Markdown Lint
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - '**/*.md'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - '**/*.md'
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install markdownlint-cli
+        run: npm install -g markdownlint-cli
+
+      - name: Run markdownlint
+        run: markdownlint '**/*.md' --fix
+
+      - name: Commit fixes
+        if: github.event_name == 'push'
+        run: |
+          if [[ -n $(git status -s) ]]; then
+            git config --global user.name 'github-actions[bot]'
+            git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+            git commit -am "Apply markdownlint fixes"
+            git push
+          fi

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,0 +1,5 @@
+default: true
+MD013:
+  line_length: 120
+MD033: false
+MD041: false

--- a/README.md
+++ b/README.md
@@ -109,6 +109,15 @@ For more details, see my [Terraform standards](https://github.com/basher83/docs/
 - [👨‍💻 Profile README](https://github.com/basher83/basher83)
 - [🏠 ProxmoxMCP Project](https://github.com/basher83/ProxmoxMCP)
 
+## 🧹 Local Markdown Linting
+
+Install [markdownlint-cli](https://github.com/igorshubovych/markdownlint-cli) to lint all Markdown files:
+
+```bash
+npm install -g markdownlint-cli
+markdownlint '**/*.md' --fix
+```
+
 ---
 
 <div align="center">


### PR DESCRIPTION
## Summary
- add markdownlint rules in `.markdownlint.yml`
- run markdownlint in new workflow with automatic fixes
- document how to run the linter locally in `README.md`

## Testing
- `npm install -g markdownlint-cli`
- `markdownlint '**/*.md' --fix`


------
https://chatgpt.com/codex/tasks/task_e_6849f07a15408333bda070d1b2768564