### PR TITLE
chore: improve workflow to reduce prs and branch creation during deve…

### DIFF
--- a/.github/workflows/update-doc-trees.yml
+++ b/.github/workflows/update-doc-trees.yml
@@ -1,15 +1,16 @@
 name: Update Documentation Trees
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - "mission-control/**"
-      - "flight-manuals/**"
-      - "star-charts/**"
-      - "maintenance-logs/**"
-      - "space-dictionary/**"
+  schedule:
+    # Run every Monday at 6 AM UTC
+    - cron: '0 6 * * 1'
   workflow_dispatch:
+    inputs:
+      create_pr:
+        description: 'Create PR instead of direct commit'
+        required: false
+        default: 'false'
+        type: boolean
 
 jobs:
   update-trees:
@@ -56,10 +57,13 @@ jobs:
             exit 0
           fi
           git commit -m "🤖 Auto-update documentation trees"
-          echo "Changes committed; will create PR in next step"
+
+      - name: Push directly to main
+        if: ${{ github.event.inputs.create_pr != 'true' }}
+        run: git push
 
       - name: Create Pull Request
-        if: ${{ success() }}
+        if: ${{ github.event.inputs.create_pr == 'true' }}
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
         with:
           commit-message: "🤖 Auto-update documentation trees"


### PR DESCRIPTION
This pull request updates the `.github/workflows/update-doc-trees.yml` workflow to improve how and when documentation trees are updated. The workflow now runs on a schedule instead of on every push, and introduces an option to create a pull request instead of committing directly to the `main` branch.

**Workflow trigger and behavior changes:**

* Changed the workflow to run on a weekly schedule (every Monday at 6 AM UTC) instead of on every push to documentation directories.
* Added a manual trigger (`workflow_dispatch`) with an input option `create_pr` that allows users to specify whether to create a pull request or push changes directly to `main`.

**Job logic updates:**

* Updated the job steps to conditionally push changes directly to `main` or create a pull request, based on the value of the `create_pr` input.