### PR TITLE
Modify badge styles and add license information

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
   
 # 🚀 Mission Control: Personal Documentation Hub 📚
 
-![GitHub last commit](https://img.shields.io/github/last-commit/basher83/docs?path=README.md&display_timestamp=committer)
-[![Profile](https://img.shields.io/badge/GitHub-basher83-181717?style=flat&logo=github)](https://github.com/basher83)
-![Status](https://img.shields.io/badge/Status-Active-brightgreen)
+![GitHub last commit](https://img.shields.io/github/last-commit/basher83/docs?path=README.md&display_timestamp=author&style=plastic&logo=github)
+[![Profile](https://img.shields.io/badge/GitHub-basher83-181717?style=plastic&logo=github)](https://github.com/basher83)
+![GitHub License](https://img.shields.io/github/license/basher83/docs?style=plastic)
 
 <!-- CI BADGES: Core automation pipelines -->
 


### PR DESCRIPTION
This pull request updates the badges at the top of the `README.md` file to improve their appearance and provide more relevant repository information.

**README badge updates:**

* Updated the "last commit" badge to use the author's timestamp, the "plastic" style, and added the GitHub logo for consistency.
* Changed the profile badge to use the "plastic" style for a unified look.
* Replaced the "Status" badge with a "License" badge to better reflect repository metadata.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refreshed README badges: last commit badge now shows the author’s timestamp with logo and plastic style; profile badge switched to plastic; removed the previous status badge and added a GitHub License badge (plastic). Badge set now presents commit timing, profile, and license details more uniformly. No other README content was modified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->