### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docs-quality.yml
+++ b/.github/workflows/docs-quality.yml
@@ -55,6 +55,8 @@ jobs:
   security-config:
     name: Actions Pinning Verification
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0


### PR DESCRIPTION
Potential fix for [https://github.com/basher83/docs/security/code-scanning/1](https://github.com/basher83/docs/security/code-scanning/1)

To fix this problem, add an explicit `permissions` block to the `security-config` job, limiting its GITHUB_TOKEN permissions to the minimum required. Since this job only runs script checks on the workflow files with no need to interact with the repository via the GitHub API, the safest and most restrictive block is `permissions: contents: read`. This should be added as the first key under the job. The edit should be made in `.github/workflows/docs-quality.yml` at the relevant line for the `security-config` job definition (right after `runs-on: ubuntu-latest`).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
